### PR TITLE
Bugfix empty settings

### DIFF
--- a/CRM/Clonecontrib/Util.php
+++ b/CRM/Clonecontrib/Util.php
@@ -14,7 +14,7 @@ class CRM_Clonecontrib_Util {
       'return' => [$settingName],
       'sequential' => 1,
     ));
-    $settingValue = $result['values'][0][$settingName];
+    $settingValue = $result['values'][0][$settingName] ?? [];
 
     if ($settingName == 'clonecontrib_skipped_fields') {
       $validOptionKeys = array_keys(self::getSkippedFieldOptions());


### PR DESCRIPTION
If the settings at civicrm/admin/clonecontrib/settings?reset=1 contain no values, it is not possible to clone a contribution.

Error message in Drupal Logs:

> array_intersect(): Argument https://github.com/twomice/civicrm-clonecontrib/pull/1 ($array) must be of type array, null given in array_intersect() (line 21 of /home/charlotte/repositories/ext/civicrm-clonecontrib/CRM/Clonecontrib/Util.php)